### PR TITLE
replace BMI example by F->C example; fixes #19

### DIFF
--- a/_episodes/01-motivation.md
+++ b/_episodes/01-motivation.md
@@ -30,17 +30,19 @@ In software tests, expected results are compared with observed results in order
 to establish accuracy:
 
 ```python
-def get_bmi(mass_kg, height_m):
+def fahrenheit_to_celsius(temp_f):
     """
-    Calculates the body mass index.
+    Converts temperature in Fahrenheit
+    to Celsius.
     """
-    return mass_kg/(height_m**2)
+    temp_c = (temp_f - 32.0) * (5.0/9.0)
+    return temp_c
 
 
-def test_get_bmi():
-    bmi = get_bmi(mass_kg=90.0, height_m=1.91)
-    expected_result = 24.670376
-    assert abs(bmi - expected_result) < 1.0e-6
+def test_fahrenheit_to_celsius():
+    temp_c = fahrenheit_to_celsius(temp_f=100.0)
+    expected_result = 37.777777
+    assert abs(temp_c - expected_result) < 1.0e-6
 ```
 
 Why are we not comparing directly all digits with the expected result?
@@ -90,28 +92,27 @@ Suiting up to modify untested code:
 #### Good code: pure and easy to test
 
 ```python
-# function which computes the body mass index
-def get_bmi(mass_kg, height_m):
-    return mass_kg/(height_m**2)
+def fahrenheit_to_celsius(temp_f):
+    temp_c = (temp_f - 32.0) * (5.0/9.0)
+    return temp_c
 
-# compute the body mass index
-bmi = get_bmi(mass_kg=90.0, height_m=1.91))
+temp_c = fahrenheit_to_celsius(temp_f=100.0)
+print(temp_c)
 ```
 
 #### Less good code: has side effects and is difficult to test
 
 ```python
-mass_kg = 90.0
-height_m = 1.91
-bmi = 0.0
+f_to_c_offset = 32.0
+f_to_c_factor = 0.555555555
+temp_c = 0.0
 
-# function which computes the body mass index
-def get_bmi():
-    global bmi
-    bmi = mass_kg/(height_m**2)
+def fahrenheit_to_celsius_bad(temp_f):
+    global temp_c
+    temp_c = (temp_f - f_to_c_offset) * f_to_c_factor
 
-# compute the body mass index
-get_bmi()
+fahrenheit_to_celsius_bad(temp_f=100.0)
+print(temp_c)
 ```
 
 ---


### PR DESCRIPTION
Once accepted I will implement the same change in the modular code lesson where the example reappears.