### PR TITLE
corrected commit message quotation marks in _episodes/07-travis.md

### DIFF
--- a/_episodes/07-travis.md
+++ b/_episodes/07-travis.md
@@ -127,7 +127,7 @@ Now you know the drill.
 ### Step 8: Fix the broken test
 
 After you have fixed the code,
-commit the following commit message "restore function subtract; fixes #1" (assuming that you try to fix issue number 1).
+commit the following commit message `"restore function subtract; fixes #1"` (assuming that you try to fix issue number 1).
 
 Once the pull request is accepted/merged, this will autoclose the issue since GitHub will recognize the "fixes #1" in the commit message, see also
 [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/).


### PR DESCRIPTION
Quotation marks in line 130 are not rendered correctly in the HTML:

>   “restore function subtract; fixes ...”

 Some users copy-paste it and get the error:

`bash: fixes: command not found`.

This pull request corrects the quotation marks rendering by marking them as code.