### PR TITLE
content/01-motivation: change R code tabs to code-tab

### DIFF
--- a/content/01-motivation.md
+++ b/content/01-motivation.md
@@ -47,7 +47,7 @@ to establish accuracy:
        assert abs(temp_c - expected_result) < 1.0e-6
    ```
 
-   ```{tab} R
+   ```{code-tab} r R
 
    To be added ...
    ```
@@ -116,7 +116,7 @@ We already know how to test this code (see above):
    print(temp_c)
    ```
 
-   ```{tab} R
+   ```{code-tab} r R
 
    To be added ...
    ```
@@ -142,7 +142,7 @@ How would you test this code:
    print(temp_c)
    ```
 
-   ```{tab} R
+   ```{code-tab} r R
 
    To be added ...
    ```


### PR DESCRIPTION
- I see why it wasn't, because it wasn't R code tab yet.  But then,
  they wouldn't all switch at once (as grouped tabs).  Clicking
  "Python" would select all Python tabs, but R would not select all R
  tabs.  It confused me a bit.
- I had to use `{code-tab} r R` to explicitely specify the name,
  otherwise the tab is shown as "S"!  I guess because S came first:
  https://pygments.org/docs/lexers/#pygments.lexers.r.SLexer
- Review: do we want to go ahead and do this now?  It's OK if not.