### PR TITLE
Add test coderefinery branding

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx_lesson',
     #'sphinx.ext.intersphinx',
     'sphinx_rtd_theme_ext_color_contrast',
+    'sphinx_coderefinery_branding',
 ]
 
 # Settings for myst_nb:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx_rtd_theme
 myst_nb
 sphinx-lesson
 sphinx_rtd_theme_ext_color_contrast
+https://github.com/coderefinery/sphinx-coderefinery-branding/archive/master.zip


### PR DESCRIPTION
- Uses new project https://github.com/coderefinery/sphinx-coderefinery-branding/
- sets HTML favicon
- Only shows the logo if built on CodeRefinery repositories
- Review: does preview work?  Is this a good idea?