### PR TITLE
the "credit and license" link went nowhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-
 # Lesson on automated testing
 
 - [Website](https://coderefinery.github.io/testing/)
-- [Credit and license](https://coderefinery.github.io/testing/license/)


### PR DESCRIPTION
this does not mean we should not have that info
we will add it