### PR TITLE
content/frameworks: pygments doesn't do fortran 2003

### DIFF
--- a/content/frameworks.md
+++ b/content/frameworks.md
@@ -130,7 +130,7 @@ TEST(example, add)
 - Very rich in functionality
 - Requires modern Fortran compilers (uses F2003 standard)
 
-```fortran
+```
 @test
 subroutine test_add_numbers()
 


### PR DESCRIPTION
- Pygments fails to highlight code when it is completely off from its
  lexer, and leaves it un-highlighted.
- The fortran example says it uses fortran 2003, apparently pigments
  can't do that.
- This removes the fortran highlighting, which doesn't change anything
  since it didn't work, but removes the warning.  It can be added back
  in someday.
- Review: does CI pass, do we accept removing the warning at risk we
  forget to add this back someday?