### PR TITLE
Fixed git pull

### DIFF
--- a/content/gh-actions.md
+++ b/content/gh-actions.md
@@ -155,7 +155,7 @@ After you committed the workflow file, your GitHub repository will be ahead of
 your local cloned repository.  Update your local cloned repository:
 
 ```bash
-$ git pull origin main
+$ git pull
 ```
 
 Next uncomment the code in `example.py` under "step 5", commit, and push.


### PR DESCRIPTION
* main branch may be undefined in a usual setup following the steps
* origin unnecessary. Or is there an educational reason for it in this case?