### PR TITLE
reorganize first steps 1-2 in continuous_integration.md

### DIFF
--- a/content/continuous-integration.md
+++ b/content/continuous-integration.md
@@ -36,23 +36,16 @@ If you are new to pull requests / merge requests, you can learn all about them
 in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborative/).
 
 
-### Step 1: Create a new repository on GitHub/GitLab or fork from the example repo
+### Step 1: Create a new repository on GitHub/GitLab OR fork from the example repo {.tabset}
 
-#### Starting from an empty repo and clone it
+#### Create a new repository
 
 - Begin by creating a repository called (for example) *example-ci*.
 - **Before** you create the repository, select **"Initialize this repository
   with a README"** (otherwise you try to clone an empty repo).
 - Clone the repository (`git clone git@github.com:<yourGitID>/example-ci.git`).
-
-#### Starting from an example repo
-
-- Fork the example repo. There are two options one for [python](https://github.com/AaltoRSE/PyTestingExample) and one for [R](https://github.com/AaltoRSE/RTestingExample).
-- Clone your fork (`git clone git@github.com:<yourGitID>/<Py/R>TestingExample.git`).
-- You can skip step 2
-
-### Step 2: Clone your repository, add code, commit, and push {.tabset}
-
+- Add the following files and code
+  
 `````{tabs}
    ````{group-tab} Python
       Add a file `functions.py` containing:
@@ -94,9 +87,7 @@ in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborati
       #        f2c(-600)
 
       ```
-      Run your tests with `pytest`.
-
-      Then stage the file (`git add <filename>`), commit (`git commit -m "some commit message"`),
+      Finally, stage the files (`git add <filename>`), commit (`git commit -m "some commit message"`),
       and push the changes (`git push origin main`).
 
    ````
@@ -196,14 +187,37 @@ in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborati
         #  expect_true(is.numeric(c));
         #})
 
-        ```
+   ````
+`````
+
+
+
+#### Start from an example repo
+
+- Fork the example repo. There are two options one for [python](https://github.com/AaltoRSE/PyTestingExample) and one for [R](https://github.com/AaltoRSE/RTestingExample).
+- Clone your fork (`git clone git@github.com:<yourGitID>/<Py/R>TestingExample.git`).
+
+
+
+### Step 2: Run tests manually {.tabset}
+`````{tabs}
+  ````{group-tab} Python
+      Run your tests with
+      ```
+      pytest
+      ```
+  ````
+  ```{group-tab} R
         You can now run your tests (and a complete check of this package) by running:
-        `Rscript -e 'testthat::test_local()'`
+        ````
+        Rscript -e 'testthat::test_local()'`
         ```{note}
         - You might need to install the testthat package before you can run the command above ( in R `install.packages("testthat")`)        
         ```
-   ````
+        ````
+  ````
 `````
+
 
 
 ### Step 3: Enable automated testing

--- a/content/continuous-integration.md
+++ b/content/continuous-integration.md
@@ -36,7 +36,7 @@ If you are new to pull requests / merge requests, you can learn all about them
 in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborative/).
 
 
-### Step 1: Create a new repository on GitHub/GitLab OR fork from the example repo {.tabset}
+### Step 1: Create a new repository on GitHub/GitLab OR fork from the example repo
 
 #### Create a new repository
 
@@ -199,23 +199,20 @@ in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborati
 
 
 
-### Step 2: Run tests locally {.tabset}
+### Step 2: Run tests locally
 `````{tabs}
   ````{group-tab} Python
-      Run your tests with
-      ```
-      pytest
-      ```
+  You can run your tests locally with
+  ```
+  pytest
+  ```
   ````
-  ```{group-tab} R
-        You can now run your tests (and a complete check of this package) by running:
-        ````
-        Rscript -e 'testthat::test_local()'`
-        ```{note}
-        - You might need to install the testthat package before you can run the command above ( in R `install.packages("testthat")`)        
-        ```
-        ````
-  ````
+  ````{group-tab} R
+  You can now run your tests (and a complete check of this package) by running:
+  ```
+  Rscript -e 'testthat::test_local()'`
+  ```
+> **_NOTE:_** You might need to install the testthat package before you can run the command above ( in R `install.packages("testthat")`)
 `````
 
 

--- a/content/continuous-integration.md
+++ b/content/continuous-integration.md
@@ -199,7 +199,7 @@ in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborati
 
 
 
-### Step 2: Run tests manually {.tabset}
+### Step 2: Run tests locally {.tabset}
 `````{tabs}
   ````{group-tab} Python
       Run your tests with


### PR DESCRIPTION
NOTE: The tabs are not rendering correctly for me locally, could this be checked?
- {.tabsets} is shown in the titles
- the text and code in tabs in Step 2 are rendered weirdly, couldn't fix it

Suggestion to reorganize first steps 1-2 in continuous_integration.md to make it a bit easier to follow after the introduction of the example repo:

1. Create a new repo OR fork an existing example repo
1.1. Instructions for creating and closing repo, adding files, git add / commit / push
1.2. Instruction for forking and cloning example repo

2.1. Run tests manually (locally)

Steps 3.-9. would remain as they are now.

The README.md of the example repo should be updated accordingly to take into account the step reorganizing.
