### PR TITLE
Fix typos, remove dead links

### DIFF
--- a/content/continuous-integration.md
+++ b/content/continuous-integration.md
@@ -194,7 +194,7 @@ in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborati
 
 #### Fork and clone an existing example repository
 
-- Fork the example repo. There are two options one for [python](https://github.com/AaltoRSE/PyTestingExample) and one for [R](https://github.com/AaltoRSE/RTestingExample).
+- Fork the example repo. There are two options one for [Python](https://github.com/AaltoRSE/PyTestingExample) and one for [R](https://github.com/AaltoRSE/RTestingExample).
 - Clone your fork (`git clone git@github.com:<yourGitID>/<Py/R>TestingExample.git`).
 
 
@@ -234,7 +234,7 @@ in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborati
   ```
 
   GitHub creates the following file for you in the subfolder `.github/workflows`.
-  Modify the highlited lines according to the action below. This will add a code coverage
+  Modify the highlighted lines according to the action below. This will add a code coverage
   report to new pull requests. The if clause restricts this to pull requests, as otherwise
   this action would not have a target to write the reports to. On pushes only the unittesting is run.
 
@@ -321,7 +321,7 @@ in the [Collaborative Git lesson](https://coderefinery.github.io/git-collaborati
     - test
   before_script:
     - cat /proc/version #print out operations system
-    - python -V  # Print out python version for debugging
+    - python -V  # Print out Python version for debugging
     - pip install pytest flake8
     - if [ -f requirements.txt ]; then pip install -r requirements.txt;fi
 
@@ -552,14 +552,14 @@ the commit message or the pull/merge request contained the correct issue number)
 
 See also:
 - GitHub: [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/)
-- GitLab: [closing issues using keywords](https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues)
+- GitLab: [closing issues using keywords](https://docs.gitlab.com/user/project/issues/managing_issues/#closing-issues-automatically)
 
 Discuss whether this is a useful feature. And if it is, why do you think is it useful?
 
 ### Step 10: Increase your code coverage
 
 We are currently missing several functions in our tests. Write a test for the `multiply` function in a new branch and create a pull request.
-On python you can directly observe the increase in code coverage.
+On Python you can directly observe the increase in code coverage.
 On R you can have a look at the action (`Actions -> last run of your action -> Select a job -> Test coverage`). If you compare this with the
 previous run, you should see an increase once the update is in.
 
@@ -582,7 +582,7 @@ Finally, we discuss together about our experiences with this exercise.
   [centralized](https://coderefinery.github.io/git-collaborative/02-centralized/) and
   [forking](https://coderefinery.github.io/git-collaborative/03-distributed/) workflows - have a look at this
   [alternative exercise](./full-cycle-ci) to see how that works.
-- GitHub Actions has a [Marketpace](https://github.com/marketplace?type=actions) which offer wide range of automatic workflows
+- GitHub Actions has a [Marketplace](https://github.com/marketplace?type=actions) which offer wide range of automatic workflows
 - On GitLab use [GitLab CI](https://about.gitlab.com/product/continuous-integration/)
 - For Windows builds you can also use [Appveyor](https://www.appveyor.com)
 

--- a/content/quick-reference.md
+++ b/content/quick-reference.md
@@ -39,10 +39,10 @@ script which does some tests.
 
 (pytest-ref)=
 
-### pytest_
+### pytest
 
 - Python
-- <http://doc.pytest.org>
+- <https://docs.pytest.org/>
 - Installable via Conda or pip.
 - Easy to use: Prefix a function with `test_` and the test runner will execute it.
   No need to subclass anything.
@@ -60,7 +60,6 @@ def test_get_word_lengths():
     assert get_word_lengths(text) == [5, 8, 3, 7, 4, 3, 6]
 ```
 
-- [Example output](https://travis-ci.org/bast/pytest-demo/builds/104182942)
 - [Example project](https://github.com/bast/pytest-demo)
 
 ---
@@ -185,9 +184,6 @@ TEST_CASE("Use the example library to add numbers", "[add]") {
 }
 ```
 
-- [Example output](https://github.com/ENCCS/catch2-demo/runs/1959590399?check_suite_focus=true)
-- [Example project](https://github.com/ENCCS/catch2-demo)
-
 ---
 
 (google-test)=
@@ -212,7 +208,6 @@ TEST(example, add) {
 }
 ```
 
-- [Example output](https://travis-ci.org/bast/gtest-demo/builds/104190982)
 - [Example project](https://github.com/bast/gtest-demo)
 
 ---
@@ -237,9 +232,6 @@ BOOST_AUTO_TEST_CASE( add )
   BOOST_TEST(res == 3.0);
 }
 ```
-
-- [Example output](https://github.com/ENCCS/boost-test-demo/runs/1959592305?check_suite_focus=true)
-- [Example project](https://github.com/ENCCS/boost-test-demo)
 
 ---
 
@@ -282,7 +274,6 @@ You can then compile using this script:
 :language: bash
 ```
 
-- [Example output](https://travis-ci.org/bast/pfunit-demo/builds/104193675)
 - [Example project](https://github.com/bast/pfunit-demo)
 
 ---
@@ -293,9 +284,9 @@ Each of these are web services to handle testing, free for open source
 projects.
 
 - [GitHub Actions](https://github.com/features/actions) (we will
-  demonstrate in next episode)
+  demonstrate this in the next episode)
 - [GitLab CI](https://about.gitlab.com/features/gitlab-ci-cd/)
-  (we will demonstrate in next episode)
+  (we will demonstrate this in the next episode)
 - [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/)
 - [Coveralls](https://coveralls.io)
 - [Codecov](https://codecov.io)
@@ -305,7 +296,6 @@ projects.
 ## Good resources
 
 - [Getting Started With Testing in Python](https://realpython.com/python-testing/)
-- [Introductions to Python Testing Frameworks](http://pythontesting.net/start-here/)
 
 
 ```{keypoints}


### PR DESCRIPTION
* Travis CI links were all dead
* GitHub repos [ENCCS/boost-test-demo](https://github.com/ENCCS/boost-test-demo) and [ENCCS/catch2-demo](https://github.com/ENCCS/catch2-demo) both seem to be gone
    * Note also that logs for GHA runs are deleted after 90 days, so using these as example outputs is not easily possible
* also updated a few links

Many thanks for the nice material; I hope to refer to this from a different intermediate Python course I’m [currently working on](https://github.com/RSE-Sheffield/pando-python/issues/74#issuecomment-2755596349). :)