### PR TITLE
fix: correct loop bounds and indexing in fizzbuzz test for C++

### DIFF
--- a/content/code/cpp/fizzbuzz.cpp
+++ b/content/code/cpp/fizzbuzz.cpp
@@ -36,7 +36,7 @@ TEST_CASE("FizzBuzz", "[fizzbuzz]") {
 	"8",        "Fizz", "Buzz", "11",   "Fizz", "13",   "14",
 	"FizzBuzz", "16",   "17",   "Fizz", "19",   "Buzz"};
 
-  for (auto i = 1; i <= 20; ++i) {
+  for (auto i = 1; i <= expected.size(); ++i) {
     REQUIRE(fizzbuzz(i) == expected[i-1]);
   }
 }

--- a/content/code/cpp/fizzbuzz.cpp
+++ b/content/code/cpp/fizzbuzz.cpp
@@ -36,8 +36,8 @@ TEST_CASE("FizzBuzz", "[fizzbuzz]") {
 	"8",        "Fizz", "Buzz", "11",   "Fizz", "13",   "14",
 	"FizzBuzz", "16",   "17",   "Fizz", "19",   "Buzz"};
 
-  for (auto i = 1; i <= 21; ++i) {
-    REQUIRE(fizzbuzz(i) == expected[i]);
+  for (auto i = 1; i <= 20; ++i) {
+    REQUIRE(fizzbuzz(i) == expected[i-1]);
   }
 }
 


### PR DESCRIPTION
This PR fixes incorrect loop bounds and indexing in the fizzbuzz test case for C++.